### PR TITLE
Fix issue #59: Apply Template Workflow: 不要ファイルのコミット除外

### DIFF
--- a/.github/workflows/apply-template.yml
+++ b/.github/workflows/apply-template.yml
@@ -78,7 +78,7 @@ jobs:
 
             if [ -n "$(git status --porcelain)" ]; then
               # Remove unwanted files before commit
-              rm -f .github/workflows/apply-template.yml README.md
+              git restore .github/workflows/apply-template.yml README.md
 
               git add .
               git commit -m "Apply template updates"

--- a/.github/workflows/apply-template.yml
+++ b/.github/workflows/apply-template.yml
@@ -77,6 +77,9 @@ jobs:
             git remote set-url origin "https://x-access-token:${{ env.GITHUB_PERSONAL_ACCESS_TOKEN }}@${REPO_URL#https://}"
 
             if [ -n "$(git status --porcelain)" ]; then
+              # Remove unwanted files before commit
+              rm -f .github/workflows/apply-template.yml README.md
+
               git add .
               git commit -m "Apply template updates"
               git push origin "$BRANCH_NAME"


### PR DESCRIPTION
This pull request fixes #59.

The change adds a command to explicitly remove the unwanted files `.github/workflows/apply-template.yml` and `README.md` right before the `git add .` and `git commit` steps in the workflow. This ensures these files are not staged or committed to the target repository. Since the removal happens only before committing and does not affect other files, it meets the acceptance criteria of excluding these specific files from the commit while preserving other necessary files. The approach is straightforward, minimal, and directly addresses the issue described.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌